### PR TITLE
add option to write files to disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ freedompp -t ts -f thetao -c ocean_month_z -s 2018 -e 2018 \
 
 recombines (-R) split files .nc.000[0-3] (-N/--nsplit=4) stored in the tar file without a prefix and write the recombined file with a chunking (-K/--chunk) of 1 time record.
 
+By default, freedompp will load netcdf files from the tar files directly into memory. There is an option to write the history files to disk, using:
+
+```
+freedompp -t ts -f so -c D2ocean_month_z -s 2012 -e 2017 \
+          -d /archive/myrun/history -o /archive/myrun/pp \
+          -W -X /work/tmpdir
+```
 
 The package can also be used in interactive python environments, with function to load and write
 timeseries and averages.
@@ -73,7 +80,7 @@ annual = compute_average('ocean_daily', 96, 100, avtype='ann',
 ```python
 from freedompp.libfreedompp import write_average
 monthly = compute_average('ocean_daily', 96, 100, avtype='mm',
-                          historydir='/archive/myrun/history', 
+                          historydir='/archive/myrun/history',
                           ppdir='/archive/myrun/pp')
 annual = compute_average('ocean_daily', 96, 100, avtype='ann',
                          historydir='/archive/myrun/history',

--- a/freedompp/libIO.py
+++ b/freedompp/libIO.py
@@ -75,6 +75,7 @@ def open_files_from_archives(
                     open_files.append(filelike(a, fnnnn))
                 else:
                     if not os.path.exists(f"{tmpdir}/{fnnnn}"):
+                        print(f"extracting {fnnnn} into {tmpdir}")
                         htar.extract(fnnnn, tmpdir)
                     open_files.append(f"{tmpdir}/{fnnnn}")
         else:
@@ -82,6 +83,7 @@ def open_files_from_archives(
                 open_files.append(filelike(a, f))
             else:
                 if not os.path.exists(f"{tmpdir}/{f}"):
+                    print(f"extracting {f} into {tmpdir}")
                     htar.extract(f, tmpdir)
                 open_files.append(f"{tmpdir}/{f}")
 

--- a/freedompp/libfreedompp.py
+++ b/freedompp/libfreedompp.py
@@ -27,6 +27,7 @@ def load_timeserie(
     recombine=False,
     nsplit=0,
     chunks=None,
+    tmpdir=None,
 ):
     """load timeserie of a field from netcdf files contained in tar files
 
@@ -50,6 +51,8 @@ def load_timeserie(
                                 e.g. nsplit=4 for *.nc.000[0-3]
         chunks (dict, optional): chunk sizes for output file, e.g. {'time':1}.
                                  Defaults to None, i.e. original chunking
+        tmpdir (str, optional): path to a temporary directory to extract history files.
+                                Mandatory if in_memory = False. Defaults to None.
 
     Returns:
         xarray.Dataset: timeserie for field and coordinates
@@ -67,6 +70,7 @@ def load_timeserie(
         recombine=recombine,
         nsplit=nsplit,
         chunks=chunks,
+        tmpdir=tmpdir,
     )
     # extract the timeserie of the chosen field
     ts = extract_timeserie(ds, field)
@@ -89,6 +93,7 @@ def write_timeserie(
     in_memory=True,
     recombine=False,
     nsplit=0,
+    tmpdir=None,
 ):
     """write timeserie of a field from netcdf files contained in tar files
 
@@ -116,6 +121,8 @@ def write_timeserie(
                                     Defaults to False.
         nsplit (int, optional): with recombine=True, total number of files.
                                 e.g. nsplit=4 for *.nc.000[0-3]
+        tmpdir (str, optional): path to a temporary directory to extract history files.
+                                Mandatory if in_memory = False. Defaults to None.
 
     """
 
@@ -131,6 +138,7 @@ def write_timeserie(
         recombine=recombine,
         nsplit=nsplit,
         chunks=chunks,
+        tmpdir=tmpdir,
     )
     # extract the timeserie of the chosen field
     ts = extract_timeserie(ds, field)
@@ -166,6 +174,7 @@ def compute_average(
     recombine=False,
     nsplit=0,
     chunks=None,
+    tmpdir=None,
 ):
     """compute averages of fields from netcdf files contained in tar files
 
@@ -193,6 +202,8 @@ def compute_average(
                                 e.g. nsplit=4 for *.nc.000[0-3]
         chunks (dict, optional): chunk sizes for output file, e.g. {'time':1}.
                                  Defaults to None, i.e. original chunking
+        tmpdir (str, optional): path to a temporary directory to extract history files.
+                                Mandatory if in_memory = False. Defaults to None.
 
     Returns:
         xarray.Dataset: average dataset
@@ -210,6 +221,7 @@ def compute_average(
         recombine=recombine,
         nsplit=nsplit,
         chunks=chunks,
+        tmpdir=tmpdir,
     )
 
     # figure out frequency of dataset or exit if it cannot
@@ -256,6 +268,7 @@ def write_average(
     in_memory=True,
     recombine=False,
     nsplit=0,
+    tmpdir=None,
 ):
     """write averages of fields from netcdf files contained in tar files
 
@@ -286,6 +299,8 @@ def write_average(
                                     Defaults to False.
         nsplit (int, optional): with recombine=True, total number of files.
                                 e.g. nsplit=4 for *.nc.000[0-3]
+        tmpdir (str, optional): path to a temporary directory to extract history files.
+                                Mandatory if in_memory = False. Defaults to None.
 
     """
 
@@ -301,6 +316,7 @@ def write_average(
         recombine=recombine,
         nsplit=nsplit,
         chunks=chunks,
+        tmpdir=tmpdir,
     )
 
     # figure out frequency of dataset or exit if it cannot

--- a/scripts/freedompp
+++ b/scripts/freedompp
@@ -99,6 +99,24 @@ parser.add_argument(
     help="if recombine=True, nsplit=total of files (e.g. 4 for  .nc.000[0-3])",
 )
 
+parser.add_argument(
+    "-W",
+    "--write_tmp_files",
+    action="store_true",
+    required=False,
+    default=False,
+    help="decompress history nc files to disk",
+)
+
+parser.add_argument(
+    "-X",
+    "--tmpdir",
+    type=str,
+    required=False,
+    default=None,
+    help="if in_memory=False, directory where to extract history nc files",
+)
+
 args = vars(parser.parse_args())
 
 # Check user inputs
@@ -115,6 +133,13 @@ if args["recombine"]:
         raise ValueError("nsplit must be non-zero with recombine=True")
     if args["chunks"] is None:
         raise ValueError("chunks must be defined with recombine=True")
+
+# switch to the internal logic
+args["in_memory"] = False if args["write_tmp_files"] else True
+args.pop("write_tmp_files")
+
+if not args["in_memory"] and (args["tmpdir"] == None):
+    raise ValueError("when decompressing files to disk, -X/--tmpdir must be passed explicitly")
 
 # Decide on what to do and handle parameters accordingly
 compute_avg = False


### PR DESCRIPTION
for systems that do not have enough memory to load all data, this extracts files into a temp directory
before `xarray.open_mfdataset`. To save time, files are only extracted if they are not found in the tmpdir
hence for multiple variables in the same file, the first one will be the longest because of extraction.

For example, with 5 years of 3D ocean data on a 1/4 degree grid:

* in_memory: walltime = 2m10s per variable
* write to disk: walltime = 5m2s for first variable/ 1m25s for second,...